### PR TITLE
First Implementation

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,5 @@
+extends:
+- "homeoffice/config/default"
+
+env:
+  es6: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: node_js
+node_js:
+  - "6"
+  - "4"
+
+before_install:
+  - if [[ `npm -v` != 3* ]]; then npm i -g npm@3; fi
+  - npm cache clean

--- a/README.md
+++ b/README.md
@@ -1,2 +1,42 @@
 # hof-middleware-markdown
-i18n-compatible markdown rendering for static content
+i18n-compatible markdown rendering for static content into templates
+
+## Usage
+
+First, mount the middleware in your app.
+
+```js
+const markdown = require('hof-middleware-markdown');
+app.use(markdown());
+```
+
+Then you can embed static markdown snippets in your templates as follows.
+
+```
+{{#markdown}}file-name{{//markdown}}
+```
+
+Snippets will be loaded from within `content` directories inside your express `views` directories. So if you have your express `views` set to `/path/to/my/views` then the markdown snippets will be looked for in `/path/to/my/views/content`.
+
+## i18n
+
+If `req.lang` is set (and it will be in hof-bootstrap apps) then content will be loaded first in directories corresponding to the request langauge.
+
+So if `req.lang` is set to `['en-US', 'en']` then the content will be loaded first from `/path/to/my/views/content/en-us` then `/path/to/my/views/content/en` and finally `/path/to/my/views/content`.
+
+Note: language codes are *always* lower case when mapped to directories.
+
+## Configuration
+
+The markdown middleware can be configured by passing options at initialisation.
+
+```js
+const markdown = require('hof-middleware-markdown');
+app.use(markdown(options));
+```
+
+### Options
+
+* `method` - Default: `markdown` - sets the name of the method exposed to templates.
+* `dir` - Default: `content` - sets the subdirectory of `views` in which to find content snippets.
+* `fallbackLang` - Default: [''] - sets the directories in which to look for content if no matching language specific directory exists.

--- a/README.md
+++ b/README.md
@@ -38,5 +38,6 @@ app.use(markdown(options));
 ### Options
 
 * `method` - Default: `markdown` - sets the name of the method exposed to templates.
+* `ext` - Default: `md` - sets the file extension of content files.
 * `dir` - Default: `content` - sets the subdirectory of `views` in which to find content snippets.
 * `fallbackLang` - Default: [''] - sets the directories in which to look for content if no matching language specific directory exists.

--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('./lib/markdown');

--- a/lib/markdown.js
+++ b/lib/markdown.js
@@ -12,21 +12,25 @@ module.exports = config => {
   config.dir = config.dir || 'content';
   config.method = config.method || 'markdown';
   config.fallbackLang = config.fallbackLang || [''];
+  config.ext = config.ext || 'md';
   return (req, res, next) => {
     const View = req.app.get('view');
     res.locals[config.method] = () => {
       return file => {
+        if (!file) {
+          throw new Error('markdown: filename must be specified');
+        }
         const views = req.app.get('views');
-        const languages = _.uniq([].concat(req.lang).concat(config.fallbackLang));
+        const languages = _.uniq([].concat(req.lang).concat(config.fallbackLang)).filter(a => typeof a === 'string');
         const paths = views.map(dir => {
           return languages.map(lang => path.resolve(dir, config.dir, lang.toLowerCase()));
         });
 
         // use express' `View` class to shortcut looking up files
         const view = new View(file, {
-          defaultEngine: 'md',
+          defaultEngine: config.ext,
           root: _.flatten(paths),
-          engines: { '.md': {} }
+          engines: { [`.${config.ext}`]: {} }
         });
 
         if (!view.path) {

--- a/lib/markdown.js
+++ b/lib/markdown.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const markdown = require('markdown').markdown;
+const path = require('path');
+const fs = require('fs');
+const _ = require('lodash');
+
+const cache = {};
+
+module.exports = config => {
+  config = config || {};
+  config.dir = config.dir || 'content';
+  config.method = config.method || 'markdown';
+  config.fallbackLang = config.fallbackLang || [''];
+  return (req, res, next) => {
+    const View = req.app.get('view');
+    res.locals[config.method] = () => {
+      return file => {
+        const views = req.app.get('views');
+        const languages = _.uniq([].concat(req.lang).concat(config.fallbackLang));
+        const paths = views.map(dir => {
+          return languages.map(lang => path.resolve(dir, config.dir, lang.toLowerCase()));
+        });
+
+        // use express' `View` class to shortcut looking up files
+        const view = new View(file, {
+          defaultEngine: 'md',
+          root: _.flatten(paths),
+          engines: { '.md': {} }
+        });
+
+        if (!view.path) {
+          throw new Error(`Could not find content: ${file}`);
+        }
+
+        const md = cache[view.path] || fs.readFileSync(view.path).toString('utf8');
+        cache[view.path] = md;
+
+        return markdown.toHTML(md);
+      };
+    };
+    next();
+  };
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "i18n-compatible markdown rendering for static content",
   "main": "index.js",
   "scripts": {
-    "test": "eslint ."
+    "test": "npm run test:lint && npm run test:unit",
+    "test:lint": "eslint .",
+    "test:unit": "mocha"
   },
   "repository": {
     "type": "git",
@@ -21,7 +23,12 @@
     "markdown": "^0.5.0"
   },
   "devDependencies": {
+    "chai": "^3.5.0",
     "eslint": "^3.16.1",
-    "eslint-config-homeoffice": "^2.1.2"
+    "eslint-config-homeoffice": "^2.1.2",
+    "mocha": "^3.2.0",
+    "reqres": "^1.2.2",
+    "sinon": "^1.17.7",
+    "sinon-chai": "^2.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "hof-middleware-markdown",
+  "version": "1.0.0",
+  "description": "i18n-compatible markdown rendering for static content",
+  "main": "index.js",
+  "scripts": {
+    "test": "eslint ."
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/UKHomeOfficeForms/hof-middleware-markdown.git"
+  },
+  "author": "Leonard Martin <hello@lennym.co.uk>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/UKHomeOfficeForms/hof-middleware-markdown/issues"
+  },
+  "homepage": "https://github.com/UKHomeOfficeForms/hof-middleware-markdown#readme",
+  "dependencies": {
+    "lodash": "^4.17.4",
+    "markdown": "^0.5.0"
+  },
+  "devDependencies": {
+    "eslint": "^3.16.1",
+    "eslint-config-homeoffice": "^2.1.2"
+  }
+}

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,6 @@
+extends:
+  - '../.eslintrc'
+  - 'homeoffice/config/testing'
+
+env:
+  es6: true

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const reqres = require('reqres');
+const chai = require('chai');
+global.expect = chai.expect;
+global.sinon = require('sinon');
+global.request = reqres.req;
+global.response = reqres.res;
+
+chai.use(require('sinon-chai'));

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,218 @@
+'use strict';
+/* global request response */
+
+const markdown = require('../');
+
+const fs = require('fs');
+
+describe('markdown middleware', () => {
+
+  let middleware;
+  let req;
+  let res;
+  let next;
+  let View;
+
+  beforeEach(() => {
+    req = request();
+    res = response();
+    next = sinon.stub();
+    req.app.get.withArgs('views').returns(['/path/to/my/views']);
+    sinon.stub(fs, 'readFileSync').returns('# some markdown');
+
+    View = sinon.spy(function(name) {
+      this.path = `/path/to/my/views/content/en/${name}.md`;
+    });
+    // this is an express internal View class by default
+    // https://github.com/expressjs/express/blob/master/lib/view.js
+    req.app.get.withArgs('view').returns(View);
+  });
+
+  afterEach(() => {
+    fs.readFileSync.restore();
+  });
+
+  it('returns a middleware function', () => {
+    middleware = markdown();
+    expect(middleware).to.be.a('function');
+    expect(middleware.length).to.equal(3);
+  });
+
+  describe('with default config', () => {
+
+    beforeEach(() => {
+      middleware = markdown();
+    });
+
+    it('calls through to next', () => {
+      middleware(req, res, next);
+      expect(next).to.have.been.calledOnce;
+      expect(next).to.have.been.calledWithExactly();
+    });
+
+    it('adds a `markdown` function to res.locals', () => {
+      middleware(req, res, next);
+      expect(res.locals.markdown).to.be.a('function');
+    });
+
+    describe('res.locals.markdown', () => {
+
+
+      beforeEach(() => {
+        fs.readFileSync
+          .withArgs('/path/to/my/views/content/en/file.md').returns('# hello world')
+          .withArgs('/path/to/my/views/content/en/other.md').returns('# hello other');
+        middleware(req, res, next);
+      });
+
+      it('returns a function with a single argument', () => {
+        const render = res.locals.markdown();
+        expect(render).to.be.a('function');
+        expect(render.length).to.equal(1);
+      });
+
+      it('throws if not passed a file name', () => {
+        expect(() => {
+          res.locals.markdown()();
+        }).to.throw();
+      });
+
+      it('instantiates an express View class', () => {
+        res.locals.markdown()('file');
+        expect(View).to.have.been.calledOnce;
+        expect(View).to.have.been.calledWithNew;
+      });
+
+      it('passes the file name to View', () => {
+        res.locals.markdown()('file');
+        expect(View).to.have.been.calledWith('file');
+      });
+
+      it('passes the `md` extension to View as an option', () => {
+        res.locals.markdown()('file');
+        expect(View).to.have.been.calledWith(sinon.match.any, sinon.match({
+          defaultEngine: 'md'
+        }));
+      });
+
+      it('passes dummy engines to View as an option', () => {
+        res.locals.markdown()('file');
+        expect(View.lastCall.args[1].engines).to.have.property('.md');
+        expect(View.lastCall.args[1].engines['.md']).to.be.ok;
+      });
+
+      it('passes an array of views to View as an option with languages added as per req.lang', () => {
+        req.lang = ['de', 'en'];
+        res.locals.markdown()('file');
+        expect(View).to.have.been.calledWith(sinon.match.any, sinon.match({
+          root: ['/path/to/my/views/content/de', '/path/to/my/views/content/en', '/path/to/my/views/content']
+        }));
+      });
+
+      it('can handle multiple views directories', () => {
+        req.lang = ['de', 'en'];
+        req.app.get.withArgs('views').returns(['/path/to/my/views', '/path/to/other/views']);
+        res.locals.markdown()('file');
+        expect(View).to.have.been.calledWith(sinon.match.any, sinon.match({
+          root: [
+            '/path/to/my/views/content/de', '/path/to/my/views/content/en', '/path/to/my/views/content',
+            '/path/to/other/views/content/de', '/path/to/other/views/content/en', '/path/to/other/views/content'
+          ]
+        }));
+      });
+
+      it('throws if View does not resolve a path', () => {
+        req.app.get.withArgs('view').returns(function() {
+          this.path = null;
+        });
+        middleware(req, res, next);
+        expect(() => {
+          res.locals.markdown()('file');
+        }).to.throw();
+      });
+
+      it('returns file contents parsed as markdown', () => {
+        expect(res.locals.markdown()('file')).to.equal('<h1>hello world</h1>');
+        expect(res.locals.markdown()('other')).to.equal('<h1>hello other</h1>');
+      });
+
+    });
+
+  });
+
+  describe('with custom config', () => {
+
+    describe('method', () => {
+
+      it('adds a method named according to `method` option to res.locals', () => {
+        middleware = markdown({ method: 'custom' });
+        middleware(req, res, next);
+        expect(res.locals.custom).to.be.a('function');
+      });
+
+    });
+
+    describe('ext', () => {
+
+      beforeEach(() => {
+        middleware = markdown({ ext: 'markdown' });
+        middleware(req, res, next);
+      });
+
+      it('passes the custom extension to View as an option', () => {
+        res.locals.markdown()('file');
+        expect(View).to.have.been.calledWith(sinon.match.any, sinon.match({
+          defaultEngine: 'markdown'
+        }));
+      });
+
+      it('passes dummy engines to View as an option', () => {
+        res.locals.markdown()('file');
+        expect(View.lastCall.args[1].engines).to.have.property('.markdown');
+        expect(View.lastCall.args[1].engines['.markdown']).to.be.ok;
+      });
+
+    });
+
+    describe('dir', () => {
+
+      beforeEach(() => {
+        middleware = markdown({ dir: 'snippets' });
+        middleware(req, res, next);
+      });
+
+      it('passes an array of views to View as an option with languages added as per req.lang', () => {
+        req.lang = ['de', 'en'];
+        res.locals.markdown()('file');
+        expect(View).to.have.been.calledWith(sinon.match.any, sinon.match({
+          root: ['/path/to/my/views/snippets/de', '/path/to/my/views/snippets/en', '/path/to/my/views/snippets']
+        }));
+      });
+
+    });
+
+    describe('fallbackLang', () => {
+
+      beforeEach(() => {
+        middleware = markdown({ fallbackLang: ['en', ''] });
+        middleware(req, res, next);
+      });
+
+      it('adds custom fallback languages to request languages', () => {
+        req.lang = ['de', 'fr'];
+        res.locals.markdown()('file');
+        expect(View).to.have.been.calledWith(sinon.match.any, sinon.match({
+          root: [
+            '/path/to/my/views/content/de',
+            '/path/to/my/views/content/fr',
+            '/path/to/my/views/content/en',
+            '/path/to/my/views/content'
+          ]
+        }));
+      });
+
+    });
+
+  });
+
+});

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,2 @@
+--recursive
+--require test/helpers


### PR DESCRIPTION
Exports a middleware which adds a template mixin function to render static markdown content into a template.

Removes the need to do [nasty json traversals](https://github.com/UKHomeOfficeForms/hof-template-partials/blob/master/views/cookies.html) to embed i18n-able static content into templates.

Instead just `{{#markdown}}file-name{{/markdown}}` inside a template and it will go find a corresponding `.md` file from a `content` subdirectory of your `views` (with support for multitple `views` directories) and it will be rendered into your template.

If we want language specifc content, it can go in a `content/{{lang}}` subdirectory of `views` and that will be looked for first when a request has the corresponding language headers.