### PR TITLE
Add `en` to fallback languages

### DIFF
--- a/lib/markdown.js
+++ b/lib/markdown.js
@@ -11,7 +11,7 @@ module.exports = config => {
   config = config || {};
   config.dir = config.dir || 'content';
   config.method = config.method || 'markdown';
-  config.fallbackLang = config.fallbackLang || [''];
+  config.fallbackLang = config.fallbackLang || ['en', ''];
   config.ext = config.ext || 'md';
   return (req, res, next) => {
     const View = req.app.get('view');


### PR DESCRIPTION
For cases where `req.lang` isn't set (such as selenium tests where no Accept-Language header is passed) or even cases where no i18n is loaded at all then content might not be loaded correctly.

Add a default fallback language of `en` to allow safe fallback to english content.